### PR TITLE
Apply policy for prismatic::schema

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure               "1.8.0"]
                  [clj-jgit                          "0.8.9"]
-                 [prismatic/schema "1.1.2"]
+                 [prismatic/schema "1.1.11"]
                  [org.clojure/tools.logging       "0.3.1"]
                  [ch.qos.logback/logback-classic "1.1.7"]
                  [cheshire "5.6.3"]                         ;for pretty print output to file


### PR DESCRIPTION
Apply policy `clojure-project-deps::prismatic::schema`:

_Lein dependencies_
```prismatic::schema (prismatic::schema@1.1.11)```

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:clojure-project-deps::prismatic::schema=e8e640d6624f072e13b3d47de896e4649d87e28cc8de566457ef541888947d36]</code>
</details>